### PR TITLE
Add renderer helpers and tests for mermaid blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+coverage/
+npm-debug.log*
+.DS_Store
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mermaid-renderer",
+  "version": "1.0.0",
+  "description": "Render mermaid code blocks on your browser",
+  "type": "module",
+  "main": "src/renderer.js",
+  "exports": {
+    ".": "./src/renderer.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "mermaid",
+    "markdown",
+    "renderer"
+  ],
+  "license": "MIT"
+}

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,67 @@
+const MERMAID_BLOCK_PATTERN = /(^[ \t]*)```mermaid[^\r\n]*\r?\n([\s\S]*?)(?:\r?\n\1```[ \t]*)(?=\r?\n|$)/gm;
+
+function dedentLines(lines) {
+  const indents = lines
+    .filter((line) => line.trim() !== '')
+    .map((line) => line.match(/^[ \t]*/)?.[0].length ?? 0);
+
+  if (indents.length === 0) {
+    return lines;
+  }
+
+  const indentSize = Math.min(...indents);
+
+  return lines.map((line) => {
+    if (line.trim() === '') {
+      return '';
+    }
+
+    const sliceStart = Math.min(indentSize, line.length);
+    return line.slice(sliceStart);
+  });
+}
+
+export function normalizeMermaidDiagram(diagram) {
+  if (typeof diagram !== 'string') {
+    throw new TypeError('Mermaid diagram must be a string');
+  }
+
+  const normalizedLineEndings = diagram.replace(/\r\n?/g, '\n');
+  const lines = normalizedLineEndings.split('\n');
+
+  while (lines.length > 0 && lines[0].trim() === '') {
+    lines.shift();
+  }
+
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+
+  if (lines.length === 0) {
+    return '';
+  }
+
+  const dedented = dedentLines(lines);
+
+  return dedented.join('\n');
+}
+
+export function renderMermaidBlocks(markdown, options = {}) {
+  if (typeof markdown !== 'string') {
+    throw new TypeError('Markdown content must be a string');
+  }
+
+  const { wrapperTag = 'div', className = 'mermaid' } = options;
+  const classAttribute = className ? ` class="${className}"` : '';
+
+  MERMAID_BLOCK_PATTERN.lastIndex = 0;
+
+  return markdown.replace(MERMAID_BLOCK_PATTERN, (_match, indent = '', diagram) => {
+    const normalizedDiagram = normalizeMermaidDiagram(diagram);
+    const inner = normalizedDiagram ? `\n${normalizedDiagram}\n` : '\n';
+    return `${indent}<${wrapperTag}${classAttribute}>${inner}${indent}</${wrapperTag}>`;
+  });
+}
+
+export { MERMAID_BLOCK_PATTERN };
+export default renderMermaidBlocks;

--- a/test/renderer.test.js
+++ b/test/renderer.test.js
@@ -1,0 +1,112 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeMermaidDiagram, renderMermaidBlocks } from '../src/renderer.js';
+
+const normalizeNewlines = (value) => value.replace(/\r\n/g, '\n');
+
+describe('normalizeMermaidDiagram', () => {
+  it('trims blank lines and dedents the diagram', () => {
+    const diagram = '\n    graph TD\n      A --> B\n      B --> C\n    \n';
+    const expected = 'graph TD\n  A --> B\n  B --> C';
+
+    assert.strictEqual(normalizeMermaidDiagram(diagram), expected);
+  });
+
+  it('returns an empty string when content is only whitespace', () => {
+    assert.strictEqual(normalizeMermaidDiagram('   \n\t\n'), '');
+  });
+
+  it('throws when the input is not a string', () => {
+    assert.throws(() => normalizeMermaidDiagram(), TypeError);
+  });
+});
+
+describe('renderMermaidBlocks', () => {
+  it('leaves text without mermaid blocks unchanged', () => {
+    const markdown = '# Title\n\nParagraph.\n';
+    assert.strictEqual(renderMermaidBlocks(markdown), markdown);
+  });
+
+  it('renders a single mermaid block as a HTML container', () => {
+    const markdown = [
+      'Diagram example:',
+      '',
+      '```mermaid',
+      '    graph TD',
+      '      A --> B',
+      '      B --> C',
+      '```',
+      'Done.'
+    ].join('\n');
+
+    const expected = [
+      'Diagram example:',
+      '',
+      '<div class="mermaid">',
+      'graph TD',
+      '  A --> B',
+      '  B --> C',
+      '</div>',
+      'Done.'
+    ].join('\n');
+
+    assert.strictEqual(renderMermaidBlocks(markdown), expected);
+  });
+
+  it('handles multiple diagrams and normalizes Windows newlines', () => {
+    const markdown = [
+      '```mermaid {init: {"theme": "forest"}}',
+      '\tsequenceDiagram',
+      '\tAlice->>Bob: Hello Bob, how are you?',
+      '```',
+      '',
+      '```mermaid',
+      'graph TD',
+      '    X --> Y',
+      '```',
+      ''
+    ].join('\r\n');
+
+    const expected = [
+      '<div class="mermaid">',
+      'sequenceDiagram',
+      'Alice->>Bob: Hello Bob, how are you?',
+      '</div>',
+      '',
+      '<div class="mermaid">',
+      'graph TD',
+      '    X --> Y',
+      '</div>',
+      ''
+    ].join('\n');
+
+    assert.strictEqual(normalizeNewlines(renderMermaidBlocks(markdown)), expected);
+  });
+
+  it('keeps surrounding indentation when a block is nested in Markdown structures', () => {
+    const markdown = [
+      '- Item',
+      '  ```mermaid',
+      '  graph TD',
+      '      A --> B',
+      '  ```',
+      '  After.'
+    ].join('\n');
+
+    const expected = [
+      '- Item',
+      '  <div class="mermaid">',
+      'graph TD',
+      '    A --> B',
+      '  </div>',
+      '  After.'
+    ].join('\n');
+
+    assert.strictEqual(renderMermaidBlocks(markdown), expected);
+  });
+
+  it('throws when markdown is not a string', () => {
+    assert.throws(() => renderMermaidBlocks(null), TypeError);
+  });
+});


### PR DESCRIPTION
## Summary
- configure the package for Node-based testing and ignore common Node artifacts
- implement helpers to normalize mermaid markdown and wrap it in HTML containers
- add node:test coverage for rendering behavior, including indentation and Windows newline scenarios

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1906f818c8324abe8a3db66687b6b